### PR TITLE
Update UserPasswordLayout.php

### DIFF
--- a/stubs/app/Orchid/Layouts/User/UserPasswordLayout.php
+++ b/stubs/app/Orchid/Layouts/User/UserPasswordLayout.php
@@ -21,14 +21,17 @@ class UserPasswordLayout extends Rows
         /** @var User $user */
         $user = $this->query->get('user');
 
-        $placeholder = $user->exists
+        $exists = $user->exists;
+        
+        $placeholder = $exists
             ? __('Leave empty to keep current password')
             : __('Enter the password to be set');
 
         return [
             Password::make('user.password')
                 ->placeholder($placeholder)
-                ->title(__('Password')),
+                ->title(__('Password'))
+                ->required(!$exists),
         ];
     }
 }


### PR DESCRIPTION
Added required for password input.

Without calling the method, the user may not always notice that it is necessary to add a password when creating a new user in the platform. This leads to a 500 error "Field 'password' doesn't have a default value"

Fixes #

## Proposed Changes

  -
  -
  -
